### PR TITLE
Fix typo 'Massachussets'

### DIFF
--- a/src/main/java/com/googlecode/javacv/cpp/dc1394.java
+++ b/src/main/java/com/googlecode/javacv/cpp/dc1394.java
@@ -32,7 +32,7 @@
  * Copyright (C) 2000-2001 SMART Technologies Inc.
  * Copyright (C) 2001-2004 Universite catholique de Louvain
  * Copyright (C) 2000 Carnegie Mellon University
- * Copyright (C) 2006- Massachussets Institute of Technology
+ * Copyright (C) 2006- Massachusetts Institute of Technology
  * Copyright (C) 2004- Nara Institute of Science and Technology
  * All files are also Copyright (C) their respective author(s)
  *


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'Massachusetts', you typed 'Massachussets'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
